### PR TITLE
Adding additional permissions for checkout

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -13,6 +13,8 @@
           "modulePermissions": [
 			"users.collection.get",
 			"circulation.requests.item.post",
+			"ui-circulation.settings.overdue-fines-policies",
+			"ui-circulation.settings.lost-item-fees-policies",
 			"inventory-storage.all",
 			"inventory-storage.items.collection.get",
 			"inventory-storage.service-points.collection.get",


### PR DESCRIPTION
Checkout receiving errors like - overdue fine policy could not be found.  Same with lost item policy.  I tried several different permissions (listed below).  None of them worked.
overdue-fine-policies.collection.get
modperms.circulation.check-out-by-barcode-post
circulation.all