### PR TITLE
MODNCIP-23: Bump inventory dependencies for Optimistic Locking

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -93,11 +93,11 @@
       },
       {
         "id":"holdings-storage",
-        "version":"4.0"
+        "version":"4.0 5.0"
       },
       {
         "id":"inventory",
-        "version":"10.2"
+        "version":"10.2 11.0"
       },
       {
         "id":"circulation",


### PR DESCRIPTION
Optimistic locking adds a `_version` property to instance,
holdings and item records. This affects GET and PUT.

mod-ncip uses POST and DELETE only and therefore is no
affected. It can bump the inventory dependency versions
safely.