### PR TITLE
MODNCIP-37 Support circulation interface v13

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -101,7 +101,7 @@
       },
       {
         "id":"circulation",
-        "version":"12.0"
+        "version":"12.0 13.0"
       }
   ],
   "permissionSets": [


### PR DESCRIPTION
### Purpose
Adapt the module to changed interface of mod-circulation from v12.0 to v13.0
### Approach
Adapt ModuleDescriptor-template to circulation interface v13.0;
### Learning
https://issues.folio.org/browse/MODNCIP-37
