### PR TITLE
MODNCIP-43: Support holdings-storage 6.0 interface

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -93,7 +93,7 @@
       },
       {
         "id":"holdings-storage",
-        "version":"4.0 5.0"
+        "version":"4.0 5.0 6.0"
       },
       {
         "id":"inventory",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-ncip only uses the holdings-storage interfaces, it doesn't use the two other interfaces.

mod-ncip is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-ncip.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json