### PR TITLE
MODNCIP-46: Replace slf4j-log4j12 by log4j-slf4j-impl fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,27 +121,27 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.18</version>
+			<version>1.7.36</version>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.7.13</version>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.17.1</version>
+			<version>2.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.17.1</version>
+			<version>2.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
-			<version>1.7.18</version>
+			<version>1.7.36</version>
 		</dependency>
 
 


### PR DESCRIPTION
Replace org.slf4j:slf4j-log4j12:1.7.13 by org.apache.logging.log4j:log4j-slf4j-impl:2.19.0.

org.slf4j:slf4j-log4j12 has log4j:log4j as transitive dependency.

log4j:log4j has reached its end of life 2015 and is no longer supported.

log4j:log4j has multiple security vulnerabilities:
https://nvd.nist.gov/vuln/detail/CVE-2022-23305
https://nvd.nist.gov/vuln/detail/CVE-2022-23302
https://nvd.nist.gov/vuln/detail/CVE-2021-4104
https://nvd.nist.gov/vuln/detail/CVE-2019-17571

Migrating from log4j:log4j to org.apache.logging.log4j:log4j-slf4j-impl fixes them.