### PR TITLE
MODNCIP-48: Use == not = for userId manualblocks lookup

### DIFF
--- a/src/main/java/org/folio/ncip/FolioRemoteServiceManager.java
+++ b/src/main/java/org/folio/ncip/FolioRemoteServiceManager.java
@@ -572,7 +572,7 @@ public class FolioRemoteServiceManager implements RemoteServiceManager {
 		final long LONG_DELAY_MS = 10000;
 
 		List<String> apiCallsNeeded = Arrays.asList(
-				baseUrl + "/manualblocks?query=(userId=" + userId + ")&limit=100",
+				baseUrl + "/manualblocks?query=(userId==" + userId + ")&limit=100",
 				baseUrl + "/automated-patron-blocks/" + userId,
 				baseUrl + "/groups/" + groupId,
 				baseUrl + "/service-points-users?query=(userId==" + userId + ")&limit=700");


### PR DESCRIPTION
Use the field match == operator, not the word match = operator when looking up menualblocks for a userId. https://dev.folio.org/faqs/explain-cql/
Only the field match == operator has a database index:
https://github.com/folio-org/mod-feesfines/blame/v18.1.1/src/main/resources/templates/db_scripts/schema.json#L94-L104
Using the word match = operator results in a full table scan with bad performance when the the manualblocks table gets bigger.