### PR TITLE
V1.14.3 temp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 1.14.2 2023-10-16
+## 1.14.3 2023-10-16
  * [MODNCIP-62](https://issues.folio.org/browse/MODNCIP-62) Upgrade dependencies (Spring, Vert.x, ...) for Poppy
 ## 1.14.1 2023-10-04
  * Fix circulation interface version

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	</licenses>
 
 	<properties>
-		<vertx.version>4.4.5</vertx.version>
+		<vertx.version>4.4.6</vertx.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.folio</groupId>
 	<artifactId>mod-ncip</artifactId>
-	<version>1.14.3</version>
+	<version>1.14.4-SNAPSHOT</version>
 	<name>NCIP</name>
 	<description>NCIP responder for FOLIO (internal module)</description>
 
@@ -234,7 +234,7 @@
 		<url>https://github.com/folio-org/mod-ncip</url>
 		<connection>scm:git:git://github.com/folio-org/mod-ncip</connection>
 		<developerConnection>scm:git:git@github.com:folio-org/mod-ncip.git</developerConnection>
-		<tag>v1.14.3</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.folio</groupId>
 	<artifactId>mod-ncip</artifactId>
-	<version>1.14.3-SNAPSHOT</version>
+	<version>1.14.3</version>
 	<name>NCIP</name>
 	<description>NCIP responder for FOLIO (internal module)</description>
 
@@ -234,7 +234,7 @@
 		<url>https://github.com/folio-org/mod-ncip</url>
 		<connection>scm:git:git://github.com/folio-org/mod-ncip</connection>
 		<developerConnection>scm:git:git@github.com:folio-org/mod-ncip.git</developerConnection>
-		<tag>HEAD</tag>
+		<tag>v1.14.3</tag>
 	</scm>
 
 	<build>


### PR DESCRIPTION
Updated to vertx 4.4.6 because of netty related security alerts (after the [MODNCIP-62](https://issues.folio.org/browse/MODNCIP-62)) updates