### PR TITLE
MODNCIP-76 -  Upgrade "holdings-storage" API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 1.15.3
+* [MODNCIP-76](https://folio-org.atlassian.net/browse/MODNCIP-76) Upgrade `holdings-storage` to 8.0
+
 ## 1.15.2 2024-10-08
 * Return user UUID in LookupUser call
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -93,7 +93,7 @@
       },
       {
         "id":"holdings-storage",
-        "version":"6.0 7.0"
+        "version":"6.0 7.0 8.0"
       },
       {
         "id":"inventory",


### PR DESCRIPTION
[MODNCIP-76](https://folio-org.atlassian.net/browse/MODNCIP-76)
Upgrade the API version in the ModuleDescriptor-template.json:

-`holdings-storage 8.0`