### PR TITLE
MODNCIP-85: Bump to NCIP2-Toolkit 4.1.2 fixing CVE-2025-48734

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>21</java.version>
-		<org.extensiblecatalog.ncip.v2.version>4.1.0</org.extensiblecatalog.ncip.v2.version>
+		<org.extensiblecatalog.ncip.v2.version>4.1.2</org.extensiblecatalog.ncip.v2.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODNCIP-85

In mod-ncip bump NCIP2-Toolkit from 4.1.0 to 4.1.2.

This indirectly upgrades commons-beanutils 1.11.0 fixing arbitrary code execution security vulnerability CVE-2025-487, see https://folio-org.atlassian.net/browse/MODNCIP-84